### PR TITLE
feat: add dark theme support and toggle

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,20 @@
 <head>
+    <script>
+      (function() {
+        try {
+          var theme = localStorage.getItem('theme');
+          var supportDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches === true;
+          if (!theme && supportDarkMode) theme = 'system';
+          if (!theme) theme = 'light';
+
+          if (theme === 'dark') {
+            document.documentElement.setAttribute('data-theme', 'dark');
+          } else if (theme === 'light') {
+            document.documentElement.setAttribute('data-theme', 'light');
+          }
+        } catch (e) {}
+      })();
+    </script>
     {% if site.google_tag_manager %}
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -82,7 +98,7 @@
     <meta name="twitter:data1" content="{{ site.author.name }}">
     <meta name="twitter:label2" content="Filed under">
     <meta name="twitter:data2" content="{% for tag in page.tags %}{{ tag }}{% unless forloop.last %}, {% endunless %}{% endfor %}">{% endif %}
-    
+
     <!-- Icons -->
     <link rel="apple-touch-icon" sizes="57x57" href="{{ "/apple-touch-icon-57x57.png" | relative_url }}">
     <link rel="apple-touch-icon" sizes="114x114" href="{{ "/apple-touch-icon-114x114.png" | relative_url }}">
@@ -99,7 +115,7 @@
     <link rel="icon" type="image/png" href="{{ "/favicon-16x16.png" | relative_url }}" sizes="16x16">
     <link rel="icon" type="image/png" href="{{ "/favicon-32x32.png" | relative_url }}" sizes="32x32">
     <link rel="shortcut icon" href="{{ "/favicon.ico" | relative_url }}">
-    
+
     {% if site.google_analytics %}
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132305607-1"></script>
     <script>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,6 +5,9 @@
       <div class="subtext-title">{{ site.description }}</div>
       <nav class="site-nav">
         {% include navigation.html %}
+        <button id="theme-toggle" class="nav-item p1" aria-label="Toggle theme">
+          <span id="theme-toggle-icon"></span>
+        </button>
       </nav>
       <div class="clearfix"></div>
       {% if site.show_social_icons %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,32 +1,117 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="{{ page.lang | default: site.lang | default: 'en' }}">
-{% include head.html %}
-<body class="site{% if site.animated %} animated fade-in-down{% endif %}">
-  {% if site.google_tag_manager %}
-  <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager }}"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-  {% endif %}
-	{% if site.facebook_comments %}
-		<div id="fb-root"></div>
-		<script>(function(d, s, id) {
-		  var js, fjs = d.getElementsByTagName(s)[0];
-		  if (d.getElementById(id)) return;
-		  js = d.createElement(s); js.id = id;
-		  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5&appId={{ site.facebook_appid }}";
-		  fjs.parentNode.insertBefore(js, fjs);
-		}(document, 'script', 'facebook-jssdk'));</script>
-	{% endif %}
+    {% include head.html %}
+    <body class="site{% if site.animated %} animated fade-in-down{% endif %}">
+        {% if site.google_tag_manager %}
+        <noscript
+            ><iframe
+                src="https://www.googletagmanager.com/ns.html?id={{ site.google_tag_manager }}"
+                height="0"
+                width="0"
+                style="display: none; visibility: hidden"
+            ></iframe
+        ></noscript>
+        {% endif %} {% if site.facebook_comments %}
+        <div id="fb-root"></div>
+        <script>
+            (function (d, s, id) {
+                var js,
+                    fjs = d.getElementsByTagName(s)[0];
+                if (d.getElementById(id)) return;
+                js = d.createElement(s);
+                js.id = id;
+                js.src =
+                    "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5&appId={{ site.facebook_appid }}";
+                fjs.parentNode.insertBefore(js, fjs);
+            })(document, "script", "facebook-jssdk");
+        </script>
+        {% endif %}
 
-  <div class="site-wrap">
-    {% include header.html %}
+        <div class="site-wrap">
+            {% include header.html %}
 
-    <div class="post p2 p-responsive wrap" role="main">
-      <div class="measure">
-        {{ content }}
-      </div>
-    </div>
-  </div>
+            <div class="post p2 p-responsive wrap" role="main">
+                <div class="measure">{{ content }}</div>
+            </div>
+        </div>
 
-  {% include footer.html %}
-</body>
+        {% include footer.html %}
+
+        <script>
+            (function () {
+                const toggleBtn = document.getElementById("theme-toggle");
+                const iconContainer =
+                    document.getElementById("theme-toggle-icon");
+                if (!toggleBtn || !iconContainer) return;
+
+                const themes = ["system", "light", "dark"];
+                const icons = {
+                    system: "💻",
+                    light: "☀️",
+                    dark: "🌙",
+                };
+
+                function getTheme() {
+                    return localStorage.getItem("theme") || "system";
+                }
+
+                function setTheme(theme) {
+                    if (theme === "system") {
+                        document.documentElement.removeAttribute("data-theme");
+                    } else {
+                        document.documentElement.setAttribute(
+                            "data-theme",
+                            theme,
+                        );
+                    }
+                    localStorage.setItem("theme", theme);
+                    updateIcon(theme);
+                }
+
+                function updateIcon(theme) {
+                    iconContainer.textContent = icons[theme];
+                    toggleBtn.setAttribute(
+                        "aria-label",
+                        `Toggle theme (current: ${theme})`,
+                    );
+                }
+
+                toggleBtn.addEventListener("click", () => {
+                    const currentTheme = getTheme();
+                    const nextTheme =
+                        themes[
+                            (themes.indexOf(currentTheme) + 1) % themes.length
+                        ];
+                    setTheme(nextTheme);
+                });
+
+                // Init icon
+                updateIcon(getTheme());
+            })();
+        </script>
+
+        <style>
+            #theme-toggle {
+                background: none;
+                border: none;
+                cursor: pointer;
+                font-size: 1rem;
+                padding: 0;
+                vertical-align: middle;
+                color: var(--nav-link-color);
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
+                margin-left: 10px;
+            }
+            #theme-toggle:hover {
+                color: var(--link-color);
+            }
+            @media (min-width: 320px) and (max-width: 1199px) {
+                #theme-toggle {
+                    font-size: 0.8rem;
+                }
+            }
+        </style>
+    </body>
 </html>

--- a/_sass/_blockquotes.scss
+++ b/_sass/_blockquotes.scss
@@ -1,16 +1,16 @@
 @use 'variables' as *;
 
 blockquote {
-  border-left: 5px solid #0076df;
+  border-left: 5px solid var(--link-color);
   font-style: italic;
   margin-left: $space-1;
   padding: $space-1;
 }
 
 blockquote footer {
-  background-color: #fff;
+  background-color: var(--blockquote-bg);
   border-color: transparent;
-  color: #7a7a7a;
+  color: var(--footer-text);
   font-size: .85rem;
   font-style: normal;
   text-align: left;

--- a/_sass/_code.scss
+++ b/_sass/_code.scss
@@ -12,7 +12,7 @@ code {
 }
 
 code {
-  color: #7a7a7a;
+  color: var(--code-text);
 }
 
 pre {
@@ -20,7 +20,8 @@ pre {
   line-height: 1.11;
   overflow-x: scroll;
   margin-bottom: 0.88em;
-  background-color: $pre-background-color;
+  background-color: var(--code-bg);
+  color: var(--code-text);
 }
 
 .highlight .p {

--- a/_sass/_footer.scss
+++ b/_sass/_footer.scss
@@ -21,9 +21,9 @@
 }
 
 footer {
-  background-color: $footer-bg-color;
-  border-top: $footer-border-top;
-  color: $footer-color;
+  background-color: var(--footer-bg);
+  border-top: thin solid var(--border-color);
+  color: var(--footer-text);
   font-size: $footer-font-size;
   font-weight: $footer-font-weight;
   padding: $footer-padding;

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -6,7 +6,7 @@
 }
 
 .site-header a {
-  color: $header-color;
+  color: var(--text-color);
   font-size: $h3;
   font-weight: $header-font-weight;
   background-image: none;
@@ -21,18 +21,18 @@
 
 .site-nav {
   padding-top: $nav-padding;
-  
+
 }
 
 .site-header nav a {
-  color: $nav-color;
+  color: var(--nav-link-color);
   @media (min-width:320px) and (max-width:1199px) {
     font-size: .8em;
   }
-  @media (min-width:1200px){ 
+  @media (min-width:1200px){
   }
- 
-  
+
+
 }
 
 .site-header nav a:hover,
@@ -41,9 +41,9 @@
 .site-header nav a.nav-active:hover,
 .site-header nav a.nav-active:focus,
 .site-header nav a.nav-active:active {
-  color: $nav-link-color;
+  color: var(--link-color);
   opacity: 1;
-  border-bottom: $nav-link-border-bottom;
+  border-bottom: 2px solid var(--link-color);
 }
 
 .site-header nav a.nav-active {

--- a/_sass/_links.scss
+++ b/_sass/_links.scss
@@ -9,7 +9,7 @@ a {
   //   rgba($link-color,.8) 18%,
   //   rgba(0,0,0,0) 17%
   // );
-  text-shadow: white 1px 0px 0px, white -1px 0px 0px;
+  text-shadow: none;
 }
 
 p a {

--- a/_sass/_pagination.scss
+++ b/_sass/_pagination.scss
@@ -9,10 +9,10 @@
   -webkit-transition: all 0.2s ease-in-out;
   -moz-transition: all 0.2s ease-in-out;
   transition: all 0.2s ease-in-out;
-  background: #fafafa;
+  background: var(--header-bg);
   border-radius: 0.1875em;
-  border: 1px solid #f3f3f3;
-  color: #333333;
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
   padding: 1em 1.5em;
 }
 
@@ -25,12 +25,12 @@
 }
 
 .pagination a:hover, .pagination a:focus {
-  background: white;
-  color: #477dca;
+  background: var(--bg-color);
+  color: var(--link-color);
 }
 
 .pagination a:active {
-  background: #f7f7f7;
+  background: var(--header-bg);
 }
 
 .pagination .button {

--- a/_sass/_posts.scss
+++ b/_sass/_posts.scss
@@ -6,7 +6,7 @@
 
 .posts .post {
   margin-bottom: 0.75em;
-  border-bottom: thin solid #f3f3f3;
+  border-bottom: thin solid var(--border-color);
 }
 
 .posts .post:last-child {
@@ -18,7 +18,7 @@
 .post-link .post-title {
   margin-top: 0;
   font-weight: 600;
-  color: #333;
+  color: var(--text-color);
   text-align: left;
 }
 
@@ -34,7 +34,7 @@ a.post-link .post-title {
     font-size: 1.3em;
     margin-top: 0;
     font-weight: 600;
-    color: #333;
+    color: var(--text-color);
     text-align: left;
   }
 
@@ -60,7 +60,7 @@ a.post-link .post-title {
   margin: 0;
   // padding: .25em 0;
   margin-bottom: 1em;
-  color: #7a7a7a;
+  color: var(--footer-text);
   // font-style: italic;
   text-align: left;
   @media (min-width:320px) and (max-width:1199px) {
@@ -75,5 +75,5 @@ a.post-link .post-title {
   color: #101820;
 }
 .related-post-title {
-  border-bottom: thin solid #f3f3f3;
+  border-bottom: thin solid var(--border-color);
 }

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,5 +1,50 @@
 @use "sass:color";
 
+:root {
+  --bg-color: #ffffff;
+  --text-color: #101820;
+  --link-color: #00A0FF;
+  --header-bg: #fafafa;
+  --footer-bg: #fafafa;
+  --border-color: #eeeeee;
+  --code-bg: #fafafa;
+  --code-text: #333333;
+  --nav-link-color: #444444;
+  --footer-text: #7a7a7a;
+  --blockquote-bg: #ffffff;
+}
+
+[data-theme='dark'] {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --link-color: #4db8ff;
+  --header-bg: #1a1a1a;
+  --footer-bg: #1a1a1a;
+  --border-color: #333333;
+  --code-bg: #1e1e1e;
+  --code-text: #d4d4d4;
+  --nav-link-color: #bbbbbb;
+  --footer-text: #999999;
+  --blockquote-bg: #1e1e1e;
+}
+
+// System preference fallback
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    --link-color: #4db8ff;
+    --header-bg: #1a1a1a;
+    --footer-bg: #1a1a1a;
+    --border-color: #333333;
+    --code-bg: #1e1e1e;
+    --code-text: #d4d4d4;
+    --nav-link-color: #bbbbbb;
+    --footer-text: #999999;
+    --blockquote-bg: #1e1e1e;
+  }
+}
+
 // Typography
 $base-font-size: 1em !default;
 $bold-font-weight: bold !default;
@@ -76,7 +121,7 @@ $space-3: 2rem !default;
 $space-4: 4rem !default;
 
 // Buttons
-$button-font-size: inherit !default; 
+$button-font-size: inherit !default;
 $button-font-weight: normal !default;
 $button-line-height: 1.125rem !default;
 $button-padding-y: .5rem !default;

--- a/_sass/basscss/_color-base.scss
+++ b/_sass/basscss/_color-base.scss
@@ -2,19 +2,19 @@
 @use '../variables' as *;
 
 body {
-  color: #101820;
-  background-color: white;
+  color: var(--text-color);
+  background-color: var(--bg-color);
   -moz-osx-font-smoothing: grayscale;
 }
 
 a {
-  color: #00A0FF;
+  color: var(--link-color);
   text-decoration: none;
 }
 
 a:hover {
   text-decoration: none;
-  
+
 }
 a:visited {
   text-decoration: none;
@@ -22,7 +22,8 @@ a:visited {
 
 pre,
 code {
-  background-color: $lighter-gray;
+  background-color: var(--code-bg);
+  color: var(--code-text);
   border-radius: $border-radius;
 }
 
@@ -30,5 +31,5 @@ hr {
   border: 0;
   border-bottom-style: solid;
   border-bottom-width: $border-width;
-  border-bottom-color: $border-color;
+  border-bottom-color: var(--border-color);
 }

--- a/docs/superpowers/plans/2026-06-13-dark-theme.md
+++ b/docs/superpowers/plans/2026-06-13-dark-theme.md
@@ -1,0 +1,275 @@
+# Dark Theme Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a three-state (Light, Dark, System) theme toggle for the JakartaDev blog with persistent storage and flash prevention.
+
+**Architecture:** 
+- Transition hardcoded colors to CSS Custom Properties.
+- Use a blocking inline script in the head to apply themes before render.
+- Implement a 3-state cycle toggle in the header.
+
+**Tech Stack:** Jekyll (Liquid), Sass, Vanilla JavaScript.
+
+---
+
+### Task 1: Define CSS Variables
+
+**Files:**
+- Modify: `_sass/_variables.scss`
+
+- [ ] **Step 1: Add CSS Variable definitions to `_sass/_variables.scss`**
+
+Add the following at the beginning of the file (after imports):
+
+```scss
+:root {
+  --bg-color: #ffffff;
+  --text-color: #101820;
+  --link-color: #00A0FF;
+  --header-bg: #fafafa;
+  --footer-bg: #fafafa;
+  --border-color: #eeeeee;
+  --code-bg: #fafafa;
+  --code-text: #333333;
+  --nav-link-color: #444444;
+  --footer-text: #7a7a7a;
+  --blockquote-bg: #ffffff;
+}
+
+[data-theme='dark'] {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --link-color: #4db8ff;
+  --header-bg: #1a1a1a;
+  --footer-bg: #1a1a1a;
+  --border-color: #333333;
+  --code-bg: #1e1e1e;
+  --code-text: #d4d4d4;
+  --nav-link-color: #bbbbbb;
+  --footer-text: #999999;
+  --blockquote-bg: #1e1e1e;
+}
+
+// System preference fallback
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --bg-color: #121212;
+    --text-color: #e0e0e0;
+    --link-color: #4db8ff;
+    --header-bg: #1a1a1a;
+    --footer-bg: #1a1a1a;
+    --border-color: #333333;
+    --code-bg: #1e1e1e;
+    --code-text: #d4d4d4;
+    --nav-link-color: #bbbbbb;
+    --footer-text: #999999;
+    --blockquote-bg: #1e1e1e;
+  }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add _sass/_variables.scss
+git commit -m "feat: define core theme variables"
+```
+
+---
+
+### Task 2: Apply Variables to Base Styles
+
+**Files:**
+- Modify: `_sass/basscss/_color-base.scss`
+
+- [ ] **Step 1: Replace hardcoded colors in `_sass/basscss/_color-base.scss`**
+
+```scss
+body {
+  color: var(--text-color);
+  background-color: var(--bg-color);
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--link-color);
+  text-decoration: none;
+}
+
+pre,
+code {
+  background-color: var(--code-bg);
+  color: var(--code-text);
+  border-radius: $border-radius;
+}
+
+hr {
+  border: 0;
+  border-bottom-style: solid;
+  border-bottom-width: $border-width;
+  border-bottom-color: var(--border-color);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add _sass/basscss/_color-base.scss
+git commit -m "feat: apply theme variables to base styles"
+```
+
+---
+
+### Task 3: Apply Variables to Layout Components
+
+**Files:**
+- Modify: `_sass/_header.scss`
+- Modify: `_sass/_footer.scss`
+- Modify: `_sass/_blockquotes.scss`
+
+- [ ] **Step 1: Update `_sass/_header.scss`**
+
+Replace hardcoded values with variables:
+`background-color: var(--header-bg);`
+`border-top: thin solid var(--border-color);` (if applicable)
+
+- [ ] **Step 2: Update `_sass/_footer.scss`**
+
+Replace hardcoded values:
+`background-color: var(--footer-bg);`
+`color: var(--footer-text);`
+
+- [ ] **Step 3: Update `_sass/_blockquotes.scss`**
+
+`background-color: var(--blockquote-bg);`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add _sass/_header.scss _sass/_footer.scss _sass/_blockquotes.scss
+git commit -m "feat: apply theme variables to header, footer, and blockquotes"
+```
+
+---
+
+### Task 4: Add Flash Prevention Script
+
+**Files:**
+- Modify: `_includes/head.html`
+
+- [ ] **Step 1: Add initialization script to `_includes/head.html`**
+
+Add this at the top of the `<head>` section, before any CSS loads:
+
+```html
+<script>
+  (function() {
+    try {
+      var theme = localStorage.getItem('theme');
+      var supportDarkMode = window.matchMedia('(prefers-color-scheme: dark)').matches === true;
+      if (!theme && supportDarkMode) theme = 'system';
+      if (!theme) theme = 'light';
+      
+      if (theme === 'dark') {
+        document.documentElement.setAttribute('data-theme', 'dark');
+      } else if (theme === 'light') {
+        document.documentElement.setAttribute('data-theme', 'light');
+      }
+      // 'system' is handled by the media query in Task 1
+    } catch (e) {}
+  })();
+</script>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add _includes/head.html
+git commit -m "feat: add theme initialization script to prevent white flash"
+```
+
+---
+
+### Task 5: Add Toggle UI and Logic
+
+**Files:**
+- Modify: `_includes/header.html`
+- Modify: `_layouts/default.html` (or create a new JS file)
+
+- [ ] **Step 1: Add Toggle Button to `_includes/header.html`**
+
+Insert after the navigation links:
+
+```html
+<button id="theme-toggle" class="nav-item p1" aria-label="Toggle theme">
+  <span id="theme-toggle-icon"></span>
+</button>
+```
+
+- [ ] **Step 2: Add Toggle Logic to `_layouts/default.html`**
+
+Add before the closing `</body>` tag:
+
+```html
+<script>
+  const toggleBtn = document.getElementById('theme-toggle');
+  const iconContainer = document.getElementById('theme-toggle-icon');
+
+  const themes = ['system', 'light', 'dark'];
+  const icons = {
+    system: '💻', // Or SVG
+    light: '☀️',
+    dark: '🌙'
+  };
+
+  function getTheme() {
+    return localStorage.getItem('theme') || 'system';
+  }
+
+  function setTheme(theme) {
+    if (theme === 'system') {
+      document.documentElement.removeAttribute('data-theme');
+    } else {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+    localStorage.setItem('theme', theme);
+    updateIcon(theme);
+  }
+
+  function updateIcon(theme) {
+    iconContainer.textContent = icons[theme];
+    toggleBtn.setAttribute('aria-label', `Toggle theme (current: ${theme})`);
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    const currentTheme = getTheme();
+    const nextTheme = themes[(themes.indexOf(currentTheme) + 1) % themes.length];
+    setTheme(nextTheme);
+  });
+
+  // Init icon
+  updateIcon(getTheme());
+</script>
+
+<style>
+  #theme-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 1.2rem;
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--nav-link-color);
+  }
+</style>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add _includes/header.html _layouts/default.html
+git commit -m "feat: add theme toggle button and logic"
+```

--- a/docs/superpowers/specs/2026-06-13-dark-theme-design.md
+++ b/docs/superpowers/specs/2026-06-13-dark-theme-design.md
@@ -1,0 +1,72 @@
+# Design Spec: Dark Theme Support for JakartaDev Blog
+
+## 1. Overview
+Implement a dark theme for the JakartaDev blog with a user-facing toggle that supports three states: Light, Dark, and System Preference.
+
+## 2. Goals
+- Provide a comfortable reading experience in low-light environments.
+- Allow users to manually override or follow their system settings.
+- Prevent "white flash" (Flash of Unstyled Content) on page load.
+- Maintain consistency with the existing Pixyll theme aesthetics.
+
+## 3. Architecture
+
+### CSS Custom Properties
+Transition core colors from Sass variables to CSS Custom Properties.
+
+```css
+:root {
+  --bg-color: #ffffff;
+  --text-color: #101820;
+  --link-color: #00A0FF;
+  --header-bg: #fafafa;
+  --footer-bg: #fafafa;
+  --border-color: #eee;
+  --code-bg: #f5f5f5;
+  --code-text: #333;
+}
+
+[data-theme='dark'] {
+  --bg-color: #121212;
+  --text-color: #e0e0e0;
+  --link-color: #00A0FF;
+  --header-bg: #1a1a1a;
+  --footer-bg: #1a1a1a;
+  --border-color: #333;
+  --code-bg: #1e1e1e;
+  --code-text: #d4d4d4;
+}
+```
+
+### Flash Prevention (Head Script)
+An inline script in `_includes/head.html` to apply the theme before rendering.
+
+```javascript
+(function() {
+  const theme = localStorage.getItem('theme') || 'system';
+  if (theme !== 'system') {
+    document.documentElement.setAttribute('data-theme', theme);
+  }
+})();
+```
+
+## 4. Components
+
+### Theme Toggle Button
+- **Location:** `_includes/header.html` (end of nav)
+- **States:** `system` (default) -> `light` -> `dark` -> `system`
+- **Icon:** SVG changing based on state.
+- **Behavior:** Cycle through states on click, updating `localStorage` and `data-theme` attribute.
+
+## 5. Implementation Steps
+1. **Variable Definition:** Add `:root` and `[data-theme]` blocks to `_sass/_variables.scss`.
+2. **Style Updates:** Replace hardcoded colors in `_sass/basscss/_color-base.scss`, `_sass/_header.scss`, `_sass/_footer.scss`, etc.
+3. **Initialization:** Add the blocking script to `_includes/head.html`.
+4. **Toggle Component:** Add the button and icons to `_includes/header.html`.
+5. **Interactive Script:** Add the toggle handling script to `_layouts/default.html` or a separate JS file.
+
+## 6. Testing
+- **System Detection:** Set OS to dark/light and check blog (when in 'system' mode).
+- **Persistence:** Switch theme, refresh page, verify it stays.
+- **Visuals:** Ensure text contrast is sufficient and links are readable.
+- **Flash Test:** Throttle network/CPU to ensure no white flash on load.


### PR DESCRIPTION
## Summary
- Implemented dark theme support using CSS custom properties.
- Added a 3-state theme toggle (Light, Dark, System) in the header.
- Implemented persistence using `localStorage` and flash prevention via an inline head script.
- Updated base styles, header, footer, code blocks, and pagination to be theme-aware.
- Removed text-shadows from links for a cleaner look.

## Test Plan
- [x] Verify theme cycles correctly (System -> Light -> Dark -> System).
- [x] Verify theme persistence after page refresh.
- [x] Verify system preference detection in 'System' mode.
- [x] Verify no 'white flash' on load when in dark mode.
- [x] Verify site builds successfully with `bundle exec jekyll build`.